### PR TITLE
Fix Operator status panels

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -2235,7 +2235,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (label_app_kubernetes_io_name) (kube_pod_status_ready{namespace=\"$operatorNamespace\"} * on (pod) group_left( label_app_kubernetes_io_name ) kube_pod_labels{label_app_kubernetes_io_name=~\"cloudnative-pg\"})",
+          "expr": "count(\r\n  sum(kube_pod_status_ready{namespace=\"$operatorNamespace\"} == 1)\r\n  by (pod,namespace)\r\n  * on (pod) group_left()\r\n  count(controller_runtime_webhook_requests_total{namespace=\"$operatorNamespace\",webhook=\"/mutate-postgresql-cnpg-io-v1-cluster\"}) by (pod)\r\n) or vector(0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Operator Status",
@@ -7995,7 +7995,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\"} * on (pod) group_left( label_app_kubernetes_io_name ) kube_pod_labels{label_app_kubernetes_io_name=~\"cloudnative-pg\"})",
+              "expr": "count(\r\n  sum(kube_pod_status_ready{namespace=\"$operatorNamespace\"} == 1)\r\n  by (pod,namespace)\r\n  * on (pod) group_left()\r\n  count(controller_runtime_webhook_requests_total{namespace=\"$operatorNamespace\",webhook=\"/mutate-postgresql-cnpg-io-v1-cluster\"}) by (pod)\r\n) or vector(0)",
               "hide": false,
               "instant": true,
               "legendFormat": "Ready Operator Pods",
@@ -8516,7 +8516,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\"} * on (pod) group_left( label_app_kubernetes_io_name ) kube_pod_labels{label_app_kubernetes_io_name=~\"cloudnative-pg\"})",
+              "expr": "count(\r\n  sum(kube_pod_status_ready{namespace=\"$operatorNamespace\"} == 1)\r\n  by (pod,namespace)\r\n  * on (pod) group_left()\r\n  count(controller_runtime_webhook_requests_total{namespace=\"$operatorNamespace\",webhook=\"/mutate-postgresql-cnpg-io-v1-cluster\"}) by (pod)\r\n) or vector(0)",
               "hide": false,
               "instant": false,
               "legendFormat": "Ready Operator Pods",
@@ -9079,7 +9079,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(controller_runtime_active_workers,namespace)",
+        "definition": "label_values(controller_runtime_webhook_requests_total{webhook=\"/mutate-postgresql-cnpg-io-v1-cluster\"},namespace)",
         "description": "Namespace where the CNPG operator is located",
         "hide": 0,
         "includeAll": false,
@@ -9089,7 +9089,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(controller_runtime_active_workers,namespace)",
+          "query": "label_values(controller_runtime_webhook_requests_total{webhook=\"/mutate-postgresql-cnpg-io-v1-cluster\"},namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
This PR fixes displaying status of Operator by using `kube_pod_status_ready == 1` and remove requirement of having kube_pod_labels.

Also it provide more targeted operatorNamespace selector which is limited by webhook that unique to CloudNative-PG

kube_pod_labels will be still needed for `topology.kubernetes.io/zone`, but this usecase can't work without knowing labels, and well - it already has good `(i)` description, so it will relatively easy for users to utilize it if they already managed to create `topology.kubernetes.io/zone` aware cluster. 