### PR TITLE
Fix descriptions of memory metrics

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -2511,7 +2511,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Excluding cache",
+      "description": "Container memory working set",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5218,7 +5218,7 @@
           "step": 10
         }
       ],
-      "title": "Memory Usage (w/o cache)",
+      "title": "Memory Usage (container memory working set)",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
The descriptions inaccurately suggest that container_memory_working_set_bytes does not include cache. It includes active page cache and excludes inactive page cache. How active/inactive page lists interact with database workloads is not widely understood or agreed on, so I would suggest we just reference the literal kubernetes metric name in the descriptions instead of trying to explain what it means. This would direct people toward the kubernetes documentation itself which is probably the most useful thing here.