### PR TITLE
Fix bugs with cluster replication health panel

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -276,14 +276,14 @@
             {
               "options": {
                 "0": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "None"
-                },
-                "1": {
-                  "color": "orange",
+                  "color": "green",
                   "index": 1,
-                  "text": "Degraded"
+                  "text": "Healthy"
+                },
+                "-1": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "None"
                 }
               },
               "type": "value"
@@ -292,9 +292,9 @@
               "options": {
                 "from": 2,
                 "result": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "Healthy"
+                  "color": "orange",
+                  "index": 2,
+                  "text": "Degraded"
                 },
                 "to": 999
               },
@@ -345,7 +345,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "max(cnpg_pg_replication_streaming_replicas{namespace=~\"$namespace\", pod=~\"$instances\"} - cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\", pod=~\"$instances\"})",
+          "expr": "(max(cnpg_pg_replication_streaming_replicas{namespace=~\"$namespace\", pod=~\"$instances\"}) - sum(cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\", pod=~\"$instances\"})) + (clamp_max(max(cnpg_pg_replication_streaming_replicas{namespace=~\"$namespace\", pod=~\"$instances\"}), 1) - 1)",
           "legendFormat": "Replication",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
The query (and subsequent value mapping) for this panel has a couple of issues:
* It shows as degraded if there is one online, available, ready replica
* It doesn't actually report if the cluster is replicating successfully, just whether or not there are two or more online, possibly erroring replicas

I've updated the query and value mapping to address both of these. Here is an easier to read version of these changes:
```C++
# -1 if the cluster has 0 replicas. 0 if there are replicas, and all are healthy. >= 1 is the number of unhealthy replicas.
# Value mappings:
# -1 = Unhealthy/no replicas
# 0 = Healthy
# >= 1 = Degraded
# Number of unhealthy replicas. Can be 0 if there are 0 replicas.
(
    # Total number of replicas
    max(cnpg_pg_replication_streaming_replicas{namespace=~"$namespace", pod=~"$instances"}) - 
    # Total number of replicas that can stream WALs
    sum(cnpg_pg_replication_is_wal_receiver_up{namespace=~"$namespace", pod=~"$instances"})
) + 
# 1 is the cluster has no replicas, 0 if the cluster has replicas
(
    # 0 if there are any replicas, -1 if there are not
    clamp_max(
        max(cnpg_pg_replication_streaming_replicas{namespace=~"$namespace", pod=~"$instances"}),
        1
    ) - 1  
)
```