### PR TITLE
Remove `-operator` from regex

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -2235,7 +2235,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+|cnpg-controller-manager.+\", condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg.+|cnpg-controller-manager.+\", condition=\"true\"})",
           "hide": false,
           "instant": true,
           "legendFormat": "Operator Status",
@@ -8153,7 +8153,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+|cnpg-controller-manager.+\", condition=\"true\"})",
+              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg.+|cnpg-controller-manager.+\", condition=\"true\"})",
               "hide": false,
               "instant": true,
               "legendFormat": "Ready Operator Pods",
@@ -8674,7 +8674,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+|cnpg-controller-manager.+\", condition=\"true\"})",
+              "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg.+|cnpg-controller-manager.+\", condition=\"true\"})",
               "hide": false,
               "instant": false,
               "legendFormat": "Ready Operator Pods",


### PR DESCRIPTION
As per https://github.com/cloudnative-pg/grafana-dashboards/pull/28#issuecomment-2812637265 this PR removes the `-operator` suffix from the regex.