### PR TITLE
ci(security): set default lint workflow permission to read-all

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - charts/
 
+permissions: read-all
+
 jobs:
   linter:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The lint.yml workflow shouldn't need any other permission than read-all

Closes #33 