### PR TITLE
Fix calculation in maintenance_work_mem panel

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -4633,7 +4633,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
               "instant": true,
               "interval": "",
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
Maintenance Work Mem panel gives wrong information.
For example 15MiB is printed when maintenance_work_mem is set at 1500MB in PostgreSQL.

Fix it by multiplying by 1024 the result of exporter metric in the dashboard.