### PR TITLE
fix: replace $__interval with $__rate_interval

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -757,7 +757,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit{namespace=~\"$namespace\",pod=~\"$instances\"}[$__interval])) + sum(rate(cnpg_pg_stat_database_xact_rollback{namespace=~\"$namespace\",pod=~\"$instances\"}[$__interval]))",
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit{namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval])) + sum(rate(cnpg_pg_stat_database_xact_rollback{namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "TPS",
           "range": true,


### PR DESCRIPTION
> Grafana recommends using $__rate_interval with the rate and increase functions instead of $__interval or a fixed interval value. Since $__rate_interval is always at least four times the scrape interval, it helps avoid issues specific to Prometheus, such as gaps or inaccuracies in query results.

https://grafana.com/docs/grafana/v12.3/datasources/prometheus/template-variables/#use-__rate_interval