### PR TITLE
Add new panel - cache hit ratio

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -5791,9 +5791,7 @@
   "targets": [
     {
       "editorMode": "code",
-      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) /
-(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) +
- sum(rate(cnpg_pg_stat_database_blks_read{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname)))*100",
+      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) / (sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) + sum(rate(cnpg_pg_stat_database_blks_read{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname)))*100",
       "legendFormat": "__auto",
       "range": true,
       "refId": "A"

--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -5722,6 +5722,100 @@
       "type": "timeseries"
     },
     {
+  "id": 56,
+  "type": "timeseries",
+  "title": "Cache hit ratio",
+    "gridPos": {
+    "x": 0,
+    "y": 49,
+    "h": 8,
+    "w": 12
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "linear",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "lineWidth": 1,
+        "fillOpacity": 0,
+        "gradientMode": "none",
+        "spanNulls": false,
+        "insertNulls": false,
+        "showPoints": "auto",
+        "showValues": false,
+        "pointSize": 5,
+        "stacking": {
+          "mode": "none",
+          "group": "A"
+        },
+        "axisPlacement": "auto",
+        "axisLabel": "",
+        "axisColorMode": "text",
+        "axisBorderShow": false,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "axisCenteredZero": false,
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "color": {
+        "mode": "palette-classic"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "red",
+            "value": 80
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "pluginVersion": "12.3.1",
+  "targets": [
+    {
+      "editorMode": "code",
+      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) /\n(sum(rate(cnpg_pg_stat_database_blks_hit{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) +\n sum(rate(cnpg_pg_stat_database_blks_read{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname)))*100",
+      "legendFormat": "__auto",
+      "range": true,
+      "refId": "A"
+    }
+  ],
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "options": {
+    "tooltip": {
+      "mode": "single",
+      "sort": "none",
+      "hideZeros": false
+    },
+    "legend": {
+      "showLegend": true,
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    }
+  }
+},
+    {
       "collapsed": true,
       "datasource": {
         "uid": "prometheus"

--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -5791,7 +5791,9 @@
   "targets": [
     {
       "editorMode": "code",
-      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) /\n(sum(rate(cnpg_pg_stat_database_blks_hit{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) +\n sum(rate(cnpg_pg_stat_database_blks_read{datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname)))*100",
+      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) /
+(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) +
+ sum(rate(cnpg_pg_stat_database_blks_read{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname)))*100",
       "legendFormat": "__auto",
       "range": true,
       "refId": "A"

--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -5791,7 +5791,7 @@
   "targets": [
     {
       "editorMode": "code",
-      "expr": "(sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) / (sum(rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname) + sum(rate(cnpg_pg_stat_database_blks_read{datname!~"template.*",datname != "",pod=~"$instances",namespace="$namespace"}[5m])) by (datname)))*100",
+      "expr": "sum(rate(cnpg_pg_stat_database_blks_hit{datname!~\"template.*\",datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) / \n (sum(rate(cnpg_pg_stat_database_blks_hit{datname!~\"template.*\",datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname) + \n sum(rate(cnpg_pg_stat_database_blks_read{datname!~\"template.*\",datname != \"\",pod=~\"$instances\",namespace=\"$namespace\"}[5m])) by (datname))*100",
       "legendFormat": "__auto",
       "range": true,
       "refId": "A"


### PR DESCRIPTION
Add a new panel to follow cache hit ratio of databases.
The panel used this promql query :

<img width="1549" height="407" alt="image" src="https://github.com/user-attachments/assets/a080fe6c-15a1-441f-969c-a99257580f12" />
