### PR TITLE
fix(security): harden GitHub Actions workflows against expression injection

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,11 +21,12 @@ jobs:
         id: create-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
           TAG="${GITHUB_REF##*/}"
           TITLE="Release ${TAG}"
           BODY="Automated PR. Will trigger the ${TAG} release when approved."
           LABEL=release
-          ASSIGNEE=${{ github.actor }}
+          ASSIGNEE="${ACTOR}"
           gh pr create --title "${TITLE}" --body "${BODY}" --label "${LABEL}" --assignee "${ASSIGNEE}" ||
           gh pr edit --title "${TITLE}" --body "${BODY}" --add-label "${LABEL}"


### PR DESCRIPTION
Move `${{ }}` expressions from `run:` blocks into step-level `env:` blocks, then reference them as properly-quoted shell variables.

Part of cloudnative-pg/cloudnative-pg#10113

Assisted-by: Claude Opus 4.6