### PR TITLE
fix: WAL health panel false positive on idle databases

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -1973,7 +1973,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "WAL is considered Healthy when the last WAL is 0min to 6min old, Delayed when it is less than 15min and Unsynced for >15min.",
+      "description": "WAL is considered Healthy when the last WAL is 0min to 6min old, Delayed when it is less than 15min and Unsynced for >15min. Idle databases with no pending WAL files are shown as Healthy.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2133,7 +2133,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "max((1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\", pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\", pod=~\"$instances\"}) +\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\", pod=~\"$instances\"}))",
+          "expr": "max((1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\", pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\", pod=~\"$instances\"}) +\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\", pod=~\"$instances\"})\n* on(pod, namespace) group_left()\n(cnpg_collector_pg_wal_archive_status{namespace=~\"$namespace\", pod=~\"$instances\", value=\"ready\"} > bool 0))",
           "hide": false,
           "instant": false,
           "legendFormat": "WAL",


### PR DESCRIPTION
## Summary

- Fixes the WAL health stat panel (ID 612) showing **"Unsynced" (red)** on idle databases where no WAL activity is occurring
- Adds a `ready > 0` guard so the panel only reports degraded status when there are actually WAL files pending archival
- Updates the panel description to document the idle database behavior

## Problem

PostgreSQL's `archive_timeout` only forces WAL segment switches when there are records in the current segment. On idle databases (common in staging/dev environments), no new WAL segments are produced, causing `seconds_since_last_archival` to grow indefinitely. The panel's thresholds (>360s = Delayed, >900s = Unsynced) trigger false positives.

Evidence from a staging environment with 3 CNPG clusters:
- All clusters showed 50,000+ seconds since last archival
- `failed_count` = 0, `ready` WALs = 0, `rate(wal_bytes)` = 0
- After a single write transaction, archiving resumed immediately (~20s)

## Fix

The query is multiplied by `cnpg_collector_pg_wal_archive_status{value="ready"} > bool 0`:
- When `ready > 0` (WALs pending): returns the actual archival age → thresholds work as before
- When `ready == 0` (nothing to archive): returns 0 → maps to "Healthy"

## Test plan

- [ ] Verify panel shows "Healthy" on an idle database with no pending WAL files
- [ ] Verify panel shows "Delayed"/"Unsynced" when WAL files are genuinely stuck (ready > 0)
- [ ] Verify panel shows correct status during normal operation with active writes

Fixes #55