### PR TITLE
Change Prometheus expression to use max function and fix "First Recoverability Point" panel (id 237)

### DIFF
--- a/charts/cluster/grafana-dashboard.json
+++ b/charts/cluster/grafana-dashboard.json
@@ -7630,7 +7630,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "{__name__=~\"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point\",namespace=~\"$namespace\",pod=~\"$instances\"}*1000 > 0",
+              "expr": "max({__name__=~\"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point\",namespace=~\"$namespace\",pod=~\"$instances\"})*1000 > 0",
               "format": "time_series",
               "interval": "",
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
Objective is to fix "First Recoverability Point" panel (id 237) returning "vector cannot contain metrics with the same labelset" error

The panel query was failing with the error "vector cannot contain metrics with the same labelset" when both metrics matched by __name__=~ share the same labelset, because Prometheus drops the __name__ label during vector evaluation, causing a collision.

The fix wraps the selector with max(), which is already used in the equivalent panel elsewhere in the same dashboard (panel id 364). This deduplicates the series and resolves the collision.

Before:
```
{__name__=~"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point",namespace=~"$namespace",pod=~"$instances"}*1000 > 0
```

<img width="2914" height="888" alt="Capture d&#39;écran 2026-05-20 165201" src="https://github.com/user-attachments/assets/491783e5-60c5-48f9-830e-9ca312ca1c57" />

After:
```
max({__name__=~"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point",namespace=~"$namespace",pod=~"$instances"})*1000 > 0
```

<img width="2914" height="911" alt="Capture d&#39;écran 2026-05-20 221641" src="https://github.com/user-attachments/assets/efa8c511-8097-42d2-af4d-6153753c7a41" />
