### PR TITLE
fix: correct OCI registry example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ helm repo add cnpg-grafana https://cloudnative-pg.github.io/grafana-dashboards
 
 If you want to use our OCI registry, signed by [cosign](https://github.com/sigstore/cosign), here is an example:
 
-```bash
+```yaml
 dependencies:
-  - name: cnpg-grafana-cluster
-    version: "0.0"
-    repository: "oci://ghcr.io/cloudnative-pg/grafana-dashboards/cluster"
+  - name: cluster
+    version: "0.0.5"
+    repository: "oci://ghcr.io/cloudnative-pg/grafana-dashboards"
 ```
 
 ### Provenance


### PR DESCRIPTION
Fixes #57

The OCI registry example in the README had two issues:

- `name` was `cnpg-grafana-cluster` instead of `cluster` (the actual chart name)
- `repository` included the chart name in the path (`/cluster`), which Helm appends automatically — causing a malformed pull URL and a 403 error

Also changed the code block language from `bash` to `yaml` since the content is a YAML snippet.